### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
  - make build
  - make test
 after_success:
- - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+ - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
  - if [ "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
     DOCKER_PUBLISH_TAG="${TRAVIS_PULL_REQUEST_BRANCH}" make publish;
    elif [ "${TRAVIS_TAG}" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
-FROM debian:jessie
+FROM ubuntu:18.04
 
-LABEL maintainer "Artem Panchenko <kazar.artem@gmail.com>"
+LABEL forkedFrom "https://github.com/artem-panchenko/counter-strike-docker"
+LABEL maintaner "ClemArt [https://github.com/ClemArt/counter-strike-docker]"
 
 ARG steam_user=anonymous
 ARG steam_password=
 ARG metamod_version=1.20
 ARG amxmod_version=1.8.2
 
-RUN apt update && apt install -y lib32gcc1 curl
+RUN apt update -q && apt install -y \
+    lib32gcc1 \
+    curl
 
 # Install SteamCMD
 RUN mkdir -p /opt/steam && cd /opt/steam && \
-    curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
+    curl -qL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
 
 # Install HLDS
 RUN mkdir -p /opt/hlds
 # Workaround for "app_update 90" bug, see https://forums.alliedmods.net/showthread.php?p=2518786
-RUN /opt/steam/steamcmd.sh +login $steam_user $steam_password +force_install_dir /opt/hlds +app_update 90 validate +quit
-RUN /opt/steam/steamcmd.sh +login $steam_user $steam_password +force_install_dir /opt/hlds +app_update 70 validate +quit || :
-RUN /opt/steam/steamcmd.sh +login $steam_user $steam_password +force_install_dir /opt/hlds +app_update 10 validate +quit || :
+RUN /opt/steam/steamcmd.sh +login $steam_user $steam_password +force_install_dir /opt/hlds +app_update 90 validate +quit || true
 RUN /opt/steam/steamcmd.sh +login $steam_user $steam_password +force_install_dir /opt/hlds +app_update 90 validate +quit
 RUN mkdir -p ~/.steam && ln -s /opt/hlds ~/.steam/sdk32
 RUN ln -s /opt/steam/ /opt/hlds/steamcmd
@@ -48,9 +49,6 @@ ADD files/dproto.cfg /opt/hlds/cstrike/dproto.cfg
 RUN curl -sqL "http://www.amxmodx.org/release/amxmodx-$amxmod_version-base-linux.tar.gz" | tar -C /opt/hlds/cstrike/ -zxvf -
 RUN curl -sqL "http://www.amxmodx.org/release/amxmodx-$amxmod_version-cstrike-linux.tar.gz" | tar -C /opt/hlds/cstrike/ -zxvf -
 ADD files/maps.ini /opt/hlds/cstrike/addons/amxmodx/configs/maps.ini
-
-# Cleanup
-RUN apt remove -y curl
 
 WORKDIR /opt/hlds
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOCKER_PUBLISH_NAME?="hlds/server"
 DOCKER_PUBLISH_TAG?=$(IMAGE_TAG)
 
 # Test tools
-SHELLCHECK_IMAGE?="koalaman/shellcheck:v0.4.6"
+SHELLCHECK_IMAGE?="koalaman/shellcheck:latest"
 TEST_CONTAINER_NAME?="test_hlds_auto"
 TEST_CONTAINER_PORT?="27111"
 HLDS_NAME?="Test auto"
@@ -31,9 +31,12 @@ test: shellcheck test-smoke test-clean
 
 .PHONY: shellcheck
 shellcheck:
-	docker run --rm -v $(PWD):/code \
-	--entrypoint sh $(SHELLCHECK_IMAGE) -c \
-	"find /code/ -type f -name '*.sh' | xargs shellcheck"
+	docker run --rm -v $(PWD):/mnt \
+	$(SHELLCHECK_IMAGE) \
+	$(wildcard *.sh)
+
+# -c \
+# "find /code/ -type f -name '*.sh' | xargs shellcheck"
 
 .PHONY: test-start-server
 test-start-server:

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -19,7 +19,7 @@ sock.settimeout(3)
 
 request_data = 'ffffffff54536f7572636520456e67696e6520517565727900'
 retries = 10
-request_bytes = bytearray(request_data.decode('hex'))
+request_bytes = bytearray(bytes.fromhex(request_data))
 
 while retries:
     retries -= 1
@@ -30,9 +30,8 @@ while retries:
         if not retries:
             raise socket.timeout('Nothing was received from HLDS')
 
-match = re.match('.*{0}.*{1}.*{2}.*'.format(server_name,
-                                            map_name,
-                                            game_name),
+expected = '.*{0}.*{1}.*{2}.*'.format(server_name, map_name, game_name)
+match = re.match(str.encode(expected, 'ASCII'),
                  response_data)
 
 assert match, ("Server discovery test failed!"


### PR DESCRIPTION
1. Updated the base docker image to the last ubuntu LTS
2. Updated shellchecker to the latest version
3. Updated the shellcheck make recipe to work with 2.
4. Fix test so that it runs with python3.x
5. Change docker login command in travis.yaml to match travis's sample commands (avoid leaking the password in stdout)
